### PR TITLE
feat: add runner execution status and duplicate functionality

### DIFF
--- a/Sources/Models/Runner.swift
+++ b/Sources/Models/Runner.swift
@@ -8,6 +8,7 @@ struct Runner: Identifiable, Codable, Sendable {
     var enabled: Bool
     var status: RunnerStatus
     var githubRunnerId: Int?
+    var busy: Bool  // Whether runner is currently executing a job
 
     init(
         id: UUID = UUID(),
@@ -16,7 +17,8 @@ struct Runner: Identifiable, Codable, Sendable {
         labels: [String] = ["macos", "mac-runner"],
         enabled: Bool = true,
         status: RunnerStatus = .stopped,
-        githubRunnerId: Int? = nil
+        githubRunnerId: Int? = nil,
+        busy: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -25,6 +27,20 @@ struct Runner: Identifiable, Codable, Sendable {
         self.enabled = enabled
         self.status = status
         self.githubRunnerId = githubRunnerId
+        self.busy = busy
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        repo = try container.decode(String.self, forKey: .repo)
+        labels = try container.decode([String].self, forKey: .labels)
+        enabled = try container.decode(Bool.self, forKey: .enabled)
+        status = try container.decode(RunnerStatus.self, forKey: .status)
+        githubRunnerId = try container.decodeIfPresent(Int.self, forKey: .githubRunnerId)
+        // Default busy to false for backward compatibility
+        busy = try container.decodeIfPresent(Bool.self, forKey: .busy) ?? false
     }
 }
 

--- a/Sources/Services/RunnerManager.swift
+++ b/Sources/Services/RunnerManager.swift
@@ -12,10 +12,16 @@ class RunnerManager: ObservableObject {
     private let isolationService = UserIsolationService.shared
     private var runnerProcesses: [UUID: Process] = [:]
     private(set) var currentSettings: AppSettings = .default
+    private var statusPollingTask: Task<Void, Never>?
 
     init() {
         loadConfiguration()
         reconcileRunnerStates()
+        startStatusPolling()
+    }
+
+    deinit {
+        statusPollingTask?.cancel()
     }
 
     // MARK: - Configuration
@@ -316,6 +322,75 @@ class RunnerManager: ObservableObject {
             }
         }
         if changed { saveConfiguration() }
+    }
+
+    // MARK: - Status Polling
+
+    /// Poll GitHub API every 10 seconds to update runner busy state
+    private func startStatusPolling() {
+        statusPollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.updateRunnerStatuses()
+                try? await Task.sleep(for: .seconds(10))
+            }
+        }
+    }
+
+    private func updateRunnerStatuses() async {
+        // Group runners by repo to minimize API calls
+        let runnersByRepo = Dictionary(grouping: runners) { $0.repo }
+
+        for (repo, runnersInRepo) in runnersByRepo {
+            // Only check runners that are currently running
+            let runningRunners = runnersInRepo.filter { $0.status == .running }
+            guard !runningRunners.isEmpty else { continue }
+
+            // Fetch remote runner status from GitHub
+            guard let remoteRunners = try? await ghService.listRemoteRunners(for: repo) else {
+                continue
+            }
+
+            // Update busy status for each runner
+            var changed = false
+            for runner in runningRunners {
+                if let index = runners.firstIndex(where: { $0.id == runner.id }),
+                   let remoteRunner = remoteRunners.first(where: { $0.name == runner.name }) {
+                    if runners[index].busy != remoteRunner.busy {
+                        runners[index].busy = remoteRunner.busy
+                        changed = true
+                    }
+                }
+            }
+
+            if changed {
+                // Don't save config for transient busy state changes
+                objectWillChange.send()
+            }
+        }
+    }
+
+    // MARK: - Duplicate Runner
+
+    /// Create a duplicate of an existing runner with a new name
+    func duplicateRunner(_ id: UUID) async throws {
+        guard let originalRunner = runners.first(where: { $0.id == id }) else {
+            throw RunnerError.notFound
+        }
+
+        // Generate new name with incrementing suffix
+        var newName = "\(originalRunner.name)-2"
+        var counter = 2
+        while runners.contains(where: { $0.name == newName }) {
+            counter += 1
+            newName = "\(originalRunner.name)-\(counter)"
+        }
+
+        // Create duplicate with same settings
+        try await addRunner(
+            name: newName,
+            repo: originalRunner.repo,
+            labels: originalRunner.labels
+        )
     }
 
     // MARK: - Private Helpers

--- a/Sources/Views/MenuBarView.swift
+++ b/Sources/Views/MenuBarView.swift
@@ -140,8 +140,31 @@ struct RunnerRow: View {
                 .frame(width: 8, height: 8)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(runner.name)
-                    .font(.headline)
+                HStack(spacing: 6) {
+                    Text(runner.name)
+                        .font(.headline)
+
+                    // Show execution status badge when runner is busy
+                    if runner.status == .running && runner.busy {
+                        Text("EXECUTING")
+                            .font(.caption2)
+                            .fontWeight(.bold)
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.orange)
+                            .cornerRadius(4)
+                    } else if runner.status == .running {
+                        Text("IDLE")
+                            .font(.caption2)
+                            .fontWeight(.medium)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.gray.opacity(0.2))
+                            .cornerRadius(4)
+                    }
+                }
 
                 Text(runner.repo)
                     .font(.caption)
@@ -190,6 +213,10 @@ struct RunnerRow: View {
                 Button("Start") {
                     Task { try? await runnerManager.startRunner(runner.id) }
                 }
+            }
+            Divider()
+            Button("Duplicate") {
+                Task { try? await runnerManager.duplicateRunner(runner.id) }
             }
             Divider()
             Button("Remove", role: .destructive) {


### PR DESCRIPTION
## Summary

This PR adds two highly requested features to Mac Runner:

1. **Status Bar with IDLE/EXECUTING indicators** — Visual feedback showing when each runner is actively executing a CI job vs sitting idle
2. **Duplicate Button** — Quick way to spawn multiple runners on the same Mac (e.g., 5 ditto-app runners for parallel CI)

## Changes

### Runner Execution Status
- Added `busy` field to `Runner` model with backward-compatible decoding
- Updated `RunnerRow` UI to display **IDLE** (gray) or **EXECUTING** (orange) badges when runner is active
- Implemented automatic status polling every 10 seconds via GitHub API
- Optimized API calls by grouping runners by repo and only checking running runners

### Duplicate Functionality
- Added `duplicateRunner()` method that clones existing runner with auto-incrementing name suffix
- Added "Duplicate" option to runner context menu
- Preserves all settings (repo, labels) from original runner

## Benefits

- **Better visibility**: Instantly see which runners are busy with CI jobs vs waiting for work
- **Easier scaling**: Spawn multiple identical runners with one click instead of manual setup
- **Minimal overhead**: Smart API polling only checks running runners and batches by repo

## Test Plan

- [ ] `swift build` compiles clean
- [ ] Add a runner and start it — verify IDLE badge appears
- [ ] Trigger a CI job — verify badge changes to EXECUTING (orange)
- [ ] Right-click runner → Duplicate — verify new runner appears with incremented name
- [ ] Duplicate multiple times — verify names increment correctly (runner-2, runner-3, etc.)
- [ ] Stop/start runners — verify status polling continues working
- [ ] Load existing config (pre-busy field) — verify backward compatibility

## Screenshots

_Will add once tested on macOS_

🤖 Generated with [Claude Code](https://claude.com/claude-code)