### PR TITLE
fix: resolve build errors from container isolation and Xcode 26 SDK

### DIFF
--- a/Sources/Services/CLIHandler.swift
+++ b/Sources/Services/CLIHandler.swift
@@ -250,6 +250,8 @@ enum CLIHandler {
             print("  Isolation: disabled")
         case .dedicatedUser(let username):
             print("  Isolation: enabled (user: \(username))")
+        case .container:
+            print("  Isolation: container (macOS 26+)")
         }
     }
 

--- a/Sources/Services/ConfigService.swift
+++ b/Sources/Services/ConfigService.swift
@@ -44,7 +44,7 @@ class RunnerDirectory {
     static func path(for runnerId: UUID, isolation: IsolationMode = .none) throws -> String {
         let baseDir: URL
         switch isolation {
-        case .none:
+        case .none, .container:
             baseDir = FileManager.default.homeDirectoryForCurrentUser
         case .dedicatedUser(let username):
             baseDir = URL(fileURLWithPath: "/Users/\(username)")
@@ -56,7 +56,7 @@ class RunnerDirectory {
             .appendingPathComponent(runnerId.uuidString, isDirectory: true)
 
         switch isolation {
-        case .none:
+        case .none, .container:
             try FileManager.default.createDirectory(
                 at: runnerDir,
                 withIntermediateDirectories: true

--- a/Sources/Services/ContainerIsolationService.swift
+++ b/Sources/Services/ContainerIsolationService.swift
@@ -80,8 +80,7 @@ class ContainerIsolationService {
         self.containerManager = try await ContainerManager(
             kernel: kernel,
             initfsReference: "ghcr.io/apple/containerization/vminit:0.13.0",
-            network: network,
-            imageStoreLocation: imageStorePath
+            network: network
         )
     }
 
@@ -97,7 +96,7 @@ class ContainerIsolationService {
         config: ContainerRunnerConfiguration
     ) async throws -> LinuxContainer {
         // Ensure container manager is initialized
-        guard let manager = containerManager else {
+        guard var manager = containerManager else {
             throw ContainerIsolationError.notInitialized
         }
 
@@ -116,10 +115,9 @@ class ContainerIsolationService {
 
             // Mount runner workspace into container
             containerConfig.mounts.append(
-                Mount(
+                .share(
                     source: config.workspaceURL.path,
-                    destination: "/runner/_work",
-                    type: "virtiofs"
+                    destination: "/runner/_work"
                 )
             )
 
@@ -145,9 +143,7 @@ class ContainerIsolationService {
             containerConfig.process.workingDirectory = "/runner"
 
             // Set environment variables
-            containerConfig.process.environment = [
-                "RUNNER_ALLOW_RUNASROOT": "1"
-            ]
+            containerConfig.process.environmentVariables.append("RUNNER_ALLOW_RUNASROOT=1")
 
             // Enable nested virtualization if requested
             if config.enableNestedVirtualization {
@@ -155,6 +151,9 @@ class ContainerIsolationService {
                 // containerConfig.enableNestedVirtualization = true
             }
         }
+
+        // Store mutated manager back
+        self.containerManager = manager
 
         // Store in active containers map
         activeContainers[id] = container
@@ -186,7 +185,7 @@ class ContainerIsolationService {
     /// - Parameter id: The container ID to delete.
     /// - Throws: If cleanup fails.
     func deleteContainer(id: String) async throws {
-        guard let manager = containerManager else {
+        guard var manager = containerManager else {
             throw ContainerIsolationError.notInitialized
         }
 
@@ -205,6 +204,7 @@ class ContainerIsolationService {
 
         // Clean up container resources via manager
         try manager.delete(id)
+        self.containerManager = manager
     }
 
     /// Cleans up all containers and shuts down the service.

--- a/Sources/Services/RunnerInstaller.swift
+++ b/Sources/Services/RunnerInstaller.swift
@@ -71,7 +71,7 @@ class RunnerInstaller {
         let pipe = Pipe()
 
         switch isolation {
-        case .none:
+        case .none, .container:
             process = Process()
             process.executableURL = URL(fileURLWithPath: "/bin/bash")
             process.arguments = ["-c", configCommand]

--- a/Sources/Services/RunnerManager.swift
+++ b/Sources/Services/RunnerManager.swift
@@ -208,7 +208,7 @@ class RunnerManager: ObservableObject {
         let pidFile = pidFilePath(for: id)
 
         switch isolation {
-        case .none:
+        case .none, .container:
             FileManager.default.createFile(atPath: logFile, contents: nil)
             guard let logHandle = FileHandle(forWritingAtPath: logFile) else {
                 throw RunnerError.startFailed
@@ -267,7 +267,7 @@ class RunnerManager: ObservableObject {
             runnerProcesses.removeValue(forKey: id)
         } else if let pid = readPID(for: id) {
             switch isolation {
-            case .none:
+            case .none, .container:
                 killProcessTree(pid)
             case .dedicatedUser(let username):
                 isolationService.killProcessTree(pid: pid, username: username)

--- a/Sources/Utils/SystemRequirements.swift
+++ b/Sources/Utils/SystemRequirements.swift
@@ -50,7 +50,7 @@ enum SystemRequirements {
 
 // MARK: - OperatingSystemVersion Comparable
 
-extension OperatingSystemVersion: @retroactive Comparable {
+extension OperatingSystemVersion: @retroactive Equatable, @retroactive Comparable {
     public static func < (lhs: OperatingSystemVersion, rhs: OperatingSystemVersion) -> Bool {
         if lhs.majorVersion != rhs.majorVersion {
             return lhs.majorVersion < rhs.majorVersion


### PR DESCRIPTION
## Summary

- Add missing `.container` case to all `IsolationMode` switch statements across CLIHandler, ConfigService, RunnerInstaller, and RunnerManager
- Fix `ContainerIsolationService` API calls to match Containerization 0.25.1 framework (wrong init params, mutating methods, `Mount` API, `environmentVariables` property)
- Fix `OperatingSystemVersion` retroactive conformance to include `@retroactive Equatable`

## Test plan

- [x] `swift build` compiles clean
- [x] `swift test` passes (11/11)
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new container isolation mode (macOS 26+ required) for runners, expanding isolation options available in CLI status output and runner configuration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->