### PR TITLE
fix: show effective isolation mode in CLI list output

### DIFF
--- a/Sources/Services/CLIHandler.swift
+++ b/Sources/Services/CLIHandler.swift
@@ -118,10 +118,10 @@ enum CLIHandler {
         let header = "  \("NAME".padding(toLength: nameW, withPad: " ", startingAt: 0))  \("REPO".padding(toLength: repoW, withPad: " ", startingAt: 0))  STATUS      \("ISOLATION".padding(toLength: isoW, withPad: " ", startingAt: 0))  LABELS"
         print(header)
 
-        for (i, runner) in runners.enumerated() {
+        for (runner, isolationText) in zip(runners, isolationTexts) {
             let status = "\(runner.status.icon) \(runner.status.rawValue)"
             let labels = runner.labels.joined(separator: ",")
-            let line = "  \(runner.name.padding(toLength: nameW, withPad: " ", startingAt: 0))  \(runner.repo.padding(toLength: repoW, withPad: " ", startingAt: 0))  \(status.padding(toLength: 10, withPad: " ", startingAt: 0))  \(isolationTexts[i].padding(toLength: isoW, withPad: " ", startingAt: 0))  \(labels)"
+            let line = "  \(runner.name.padding(toLength: nameW, withPad: " ", startingAt: 0))  \(runner.repo.padding(toLength: repoW, withPad: " ", startingAt: 0))  \(status.padding(toLength: 10, withPad: " ", startingAt: 0))  \(isolationText.padding(toLength: isoW, withPad: " ", startingAt: 0))  \(labels)"
             print(line)
         }
     }


### PR DESCRIPTION
## Summary
- `mac-runner list` now resolves and displays the **effective** isolation mode instead of a generic "🌐 Global" label
- Runners inheriting the global setting show a "(global)" suffix, e.g. `👤 User (_macrunner) (global)`
- Isolation column width is now dynamic to accommodate longer labels

## Test plan
- [ ] Run `mac-runner setup` then `mac-runner list` — runners should show `👤 User (_macrunner) (global)` instead of `🌐 Global`
- [ ] Add a runner with `--isolation user` and verify it shows `👤 User (_macrunner)` (no "(global)" suffix)
- [ ] Add a runner with `--isolation none` and verify it shows `🔓 None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * ISOLATION column now auto-sizes to content, improving table alignment and readability.
  * Isolation status text is precomputed for list views, yielding more consistent and stable isolation displays across rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->