### PR TITLE
fix: set TMPDIR for service user to fix oxfmt DataCloneError

### DIFF
--- a/Sources/Services/UserIsolationService.swift
+++ b/Sources/Services/UserIsolationService.swift
@@ -106,6 +106,11 @@ class UserIsolationService {
                 errorMessage: "Failed to create directory: \(dir)"
             )
         }
+        // Ensure TMPDIR is private
+        try ProcessExecutor.runSudoOrThrow(
+            arguments: ["chmod", "700", tmpPath],
+            errorMessage: "Failed to set permissions on TMPDIR: \(tmpPath)"
+        )
 
         // Write .zprofile with Homebrew PATH, resource limits, and TMPDIR
         let zprofileContent = """


### PR DESCRIPTION
## Summary

• Creates a dedicated `~/.tmp` directory for the service user during home directory setup
• Exports `TMPDIR` in `.zprofile` pointing to the user-owned temp directory
• Fixes `DataCloneError: The object can not be cloned` errors from oxfmt's Prettier worker threads

## Root cause

When running in user-level isolation (`sudo -u _macrunner`), the service user doesn't get a macOS launchd session. This means `TMPDIR` is either unset or inherited from the invoking user (e.g. `/var/folders/xx/.../T/`), which the service user may not have write access to.

Bun and Node.js use `TMPDIR` for worker thread IPC (structured clone serialization). When the temp directory isn't writable, the worker communication fails with `DataCloneError` instead of a clear permissions error.

## Test plan

- [ ] Verify `~/.tmp` is created with correct ownership during setup
- [ ] Verify `echo $TMPDIR` shows the user's temp dir when running as service user
- [ ] Re-run ditto-app CI to confirm oxfmt no longer crashes on `.md`/`.css` files in hidden directories

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure a writable temporary directory (TMPDIR) is created, configured and restricted to the service user to improve runtime reliability.
  * Ensure executed commands consistently pick up PATH and TMPDIR settings.

* **Chores**
  * Switch user command execution to use zsh so profile settings are sourced consistently; privilege rules expanded to allow both zsh and bash invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->