### PR TITLE
feat: include org repos in Browse picker with search

### DIFF
--- a/Sources/Services/GHCLIService.swift
+++ b/Sources/Services/GHCLIService.swift
@@ -85,8 +85,14 @@ final class GHCLIService: Sendable {
 
     // MARK: - Repos
 
-    func listRepos() async throws -> [String] {
-        let result = try await runGH(["repo", "list", "--json", "nameWithOwner", "--limit", "50"])
+    func listRepos(owner: String? = nil) async throws -> [String] {
+        var args = ["repo", "list"]
+        if let owner {
+            args.append(owner)
+        }
+        args += ["--json", "nameWithOwner", "--limit", "100"]
+
+        let result = try await runGH(args)
         guard result.exitCode == 0 else {
             throw GHError.apiFailed("Failed to list repos: \(result.stderr)")
         }
@@ -98,6 +104,39 @@ final class GHCLIService: Sendable {
         let data = Data(result.stdout.utf8)
         let repos = try JSONDecoder().decode([RepoEntry].self, from: data)
         return repos.map(\.nameWithOwner)
+    }
+
+    func listOrgs() async throws -> [String] {
+        let result = try await runGH(["api", "/user/orgs", "--jq", ".[].login"])
+        guard result.exitCode == 0 else {
+            throw GHError.apiFailed("Failed to list orgs: \(result.stderr)")
+        }
+        guard !result.stdout.isEmpty else { return [] }
+        return result.stdout.components(separatedBy: "\n").filter { !$0.isEmpty }
+    }
+
+    func listAllRepos() async throws -> (personal: [String], orgRepos: [(org: String, repos: [String])]) {
+        async let personalRepos = listRepos()
+        async let orgs = listOrgs()
+
+        let fetchedOrgs = try await orgs
+        let fetchedPersonal = try await personalRepos
+
+        let orgResults = try await withThrowingTaskGroup(of: (String, [String]).self) { group in
+            for org in fetchedOrgs {
+                group.addTask {
+                    let repos = try await self.listRepos(owner: org)
+                    return (org, repos)
+                }
+            }
+            var results: [(String, [String])] = []
+            for try await result in group {
+                results.append(result)
+            }
+            return results.sorted { $0.0.lowercased() < $1.0.lowercased() }
+        }
+
+        return (personal: fetchedPersonal, orgRepos: orgResults)
     }
 
     func validateRepo(_ repo: String) async throws -> Bool {

--- a/Sources/Views/AddRunnerView.swift
+++ b/Sources/Views/AddRunnerView.swift
@@ -9,7 +9,8 @@ struct AddRunnerView: View {
     @State private var labelsText = "macos, mac-runner"
     @State private var selectedIsolation: IsolationSelection = .global
     @State private var enableGUI = false
-    @State private var repos: [String] = []
+    @State private var repoSections: [(header: String, repos: [String])] = []
+    @State private var repoSearchText = ""
     @State private var isLoadingRepos = false
     @State private var showRepoPicker = false
     @State private var isAdding = false
@@ -30,6 +31,17 @@ struct AddRunnerView: View {
             case .user: return .dedicatedUser(username: IsolationMode.defaultUsername)
             case .container: return .container
             }
+        }
+    }
+
+    private var filteredSections: [(header: String, repos: [String])] {
+        if repoSearchText.isEmpty {
+            return repoSections
+        }
+        let query = repoSearchText.lowercased()
+        return repoSections.compactMap { section in
+            let filtered = section.repos.filter { $0.lowercased().contains(query) }
+            return filtered.isEmpty ? nil : (header: section.header, repos: filtered)
         }
     }
 
@@ -73,36 +85,65 @@ struct AddRunnerView: View {
                             }
                         }
 
-                        if showRepoPicker, !repos.isEmpty {
-                            ScrollView {
-                                VStack(alignment: .leading, spacing: 0) {
-                                    ForEach(repos, id: \.self) { r in
-                                        Button(action: {
-                                            repo = r
-                                            showRepoPicker = false
-                                        }) {
-                                            HStack {
-                                                Text(r)
-                                                    .font(.system(.caption, design: .monospaced))
-                                                Spacer()
-                                                if r == repo {
-                                                    Image(systemName: "checkmark")
-                                                        .foregroundColor(.accentColor)
-                                                        .font(.caption)
+                        if showRepoPicker, !repoSections.isEmpty {
+                            VStack(spacing: 0) {
+                                TextField("Search repos...", text: $repoSearchText)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.caption)
+                                    .padding(6)
+
+                                Divider()
+
+                                if filteredSections.isEmpty {
+                                    Text("No matching repos")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                        .padding(8)
+                                } else {
+                                    ScrollView {
+                                        VStack(alignment: .leading, spacing: 0) {
+                                            ForEach(filteredSections, id: \.header) { section in
+                                                Text(section.header)
+                                                    .font(.system(.caption2, design: .monospaced))
+                                                    .fontWeight(.semibold)
+                                                    .foregroundColor(.secondary)
+                                                    .padding(.horizontal, 8)
+                                                    .padding(.top, 8)
+                                                    .padding(.bottom, 4)
+
+                                                ForEach(section.repos, id: \.self) { r in
+                                                    Button(action: {
+                                                        repo = r
+                                                        showRepoPicker = false
+                                                        repoSearchText = ""
+                                                    }) {
+                                                        HStack {
+                                                            Text(r)
+                                                                .font(.system(.caption, design: .monospaced))
+                                                            Spacer()
+                                                            if r == repo {
+                                                                Image(systemName: "checkmark")
+                                                                    .foregroundColor(.accentColor)
+                                                                    .font(.caption)
+                                                            }
+                                                        }
+                                                        .contentShape(Rectangle())
+                                                        .padding(.vertical, 4)
+                                                        .padding(.horizontal, 8)
+                                                    }
+                                                    .buttonStyle(.plain)
+                                                }
+
+                                                if section.header != filteredSections.last?.header {
+                                                    Divider()
+                                                        .padding(.top, 4)
                                                 }
                                             }
-                                            .contentShape(Rectangle())
-                                            .padding(.vertical, 4)
-                                            .padding(.horizontal, 8)
-                                        }
-                                        .buttonStyle(.plain)
-                                        if r != repos.last {
-                                            Divider()
                                         }
                                     }
+                                    .frame(maxHeight: 200)
                                 }
                             }
-                            .frame(height: min(CGFloat(repos.count) * 28, 140))
                             .background(Color.gray.opacity(0.1))
                             .cornerRadius(6)
                             .overlay(
@@ -215,7 +256,17 @@ struct AddRunnerView: View {
         errorMessage = nil
 
         do {
-            repos = try await GHCLIService.shared.listRepos()
+            let allRepos = try await GHCLIService.shared.listAllRepos()
+            var sections: [(header: String, repos: [String])] = []
+
+            if !allRepos.personal.isEmpty {
+                sections.append((header: "Personal", repos: allRepos.personal.sorted()))
+            }
+            for (org, repos) in allRepos.orgRepos where !repos.isEmpty {
+                sections.append((header: org, repos: repos.sorted()))
+            }
+
+            repoSections = sections
             showRepoPicker = true
         } catch {
             errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary

- Fetches repos from all of the user's GitHub organizations (via `gh api /user/orgs`) in addition to personal repos
- Fetches org repos in parallel using Swift structured concurrency (`TaskGroup`)
- Groups results by owner (Personal / each org) with section headers
- Adds inline search field to filter across all repos
- Increases per-owner limit from 50 to 100

## Problem

The "Browse" button in Add Runner only ran `gh repo list` without an `--owner` flag, which returns only the authenticated user's personal repos. Organization repos (the primary use case for self-hosted runners) were missing entirely.

Closes #37

## Changes

**`GHCLIService.swift`:**
- `listRepos(owner:)` — accepts optional owner parameter
- `listOrgs()` — discovers user's org memberships via GitHub API
- `listAllRepos()` — aggregates personal + all org repos in parallel

**`AddRunnerView.swift`:**
- Repo picker now shows grouped sections (Personal, then each org)
- Search field filters across all sections in real time
- Taller dropdown (`maxHeight: 200`) to accommodate more results

## Test plan

- [ ] Click Browse — verify both personal and org repos appear
- [ ] Verify repos are grouped under correct section headers
- [ ] Type in search field — verify filtering works across sections
- [ ] Select a repo — verify it populates the text field and closes picker
- [ ] User with no org memberships — verify only Personal section shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)