### PR TITLE
fix: resolve duplicate runner naming race condition and add bulk creation

### DIFF
--- a/Sources/Services/RunnerManager.swift
+++ b/Sources/Services/RunnerManager.swift
@@ -34,6 +34,8 @@ class RunnerManager: ObservableObject {
     private(set) var currentSettings: AppSettings = .default
     private var statusPollingTask: Task<Void, Never>?
     private var runnersToAutoRestart: Set<UUID> = []
+    /// Names reserved by in-flight addRunner calls to prevent duplicate naming race conditions.
+    private var pendingRunnerNames: Set<String> = []
 
     /// Initialize the RunnerManager and restore runtime state.
     ///
@@ -558,19 +560,60 @@ class RunnerManager: ObservableObject {
 
     // MARK: - Duplicate Runner
 
-    /// Create a duplicate of an existing runner with a new name
+    /// Strip a trailing `-N` numeric suffix from a runner name to get the base name.
+    ///
+    /// Examples:
+    /// - `"my-runner-2"` → `"my-runner"`
+    /// - `"my-runner"` → `"my-runner"`
+    /// - `"my-runner-2-3"` → `"my-runner-2"`
+    static func baseName(from name: String) -> String {
+        guard let dashRange = name.range(of: "-", options: .backwards) else {
+            return name
+        }
+        let suffix = String(name[dashRange.upperBound...])
+        if suffix.allSatisfy(\.isNumber), !suffix.isEmpty {
+            return String(name[..<dashRange.lowerBound])
+        }
+        return name
+    }
+
+    /// Generate a unique runner name by incrementing a numeric suffix.
+    ///
+    /// Checks both the existing `runners` array and `pendingRunnerNames`
+    /// to avoid race conditions when multiple duplications or bulk creations
+    /// are in flight concurrently.
+    ///
+    /// - Parameter base: The base name without numeric suffix
+    /// - Returns: A unique name like `"base-2"`, `"base-3"`, etc.
+    func generateUniqueRunnerName(base: String) -> String {
+        let allNames = Set(runners.map(\.name)).union(pendingRunnerNames)
+        var counter = 2
+        var candidate = "\(base)-\(counter)"
+        while allNames.contains(candidate) {
+            counter += 1
+            candidate = "\(base)-\(counter)"
+        }
+        return candidate
+    }
+
+    /// Create a duplicate of an existing runner with a new name.
+    ///
+    /// Strips any trailing numeric suffix from the original name to determine
+    /// the base, then generates the next available incremented name. The name
+    /// is reserved in `pendingRunnerNames` before the async `addRunner` call
+    /// to prevent race conditions when duplicating rapidly.
     func duplicateRunner(_ id: UUID) async throws {
         guard let originalRunner = runners.first(where: { $0.id == id }) else {
             throw RunnerError.notFound
         }
 
-        // Generate new name with incrementing suffix
-        var newName = "\(originalRunner.name)-2"
-        var counter = 2
-        while runners.contains(where: { $0.name == newName }) {
-            counter += 1
-            newName = "\(originalRunner.name)-\(counter)"
-        }
+        // Strip trailing -N suffix so duplicating "runner-2" yields "runner-3" not "runner-2-2"
+        let base = Self.baseName(from: originalRunner.name)
+        let newName = generateUniqueRunnerName(base: base)
+
+        // Reserve the name before async work to prevent duplicates
+        pendingRunnerNames.insert(newName)
+        defer { pendingRunnerNames.remove(newName) }
 
         // Create duplicate with same settings, preserving isolation mode and GUI access
         try await addRunner(
@@ -580,6 +623,88 @@ class RunnerManager: ObservableObject {
             isolationMode: originalRunner.isolationMode,
             enableGUI: originalRunner.enableGUI
         )
+    }
+
+    // MARK: - Bulk Runner Creation
+
+    /// Create multiple runner instances with auto-numbered names.
+    ///
+    /// When `count` is 1, creates a single runner with the exact `baseName` (current behavior).
+    /// When `count` > 1, creates runners named `baseName-1`, `baseName-2`, etc.
+    /// Names are reserved upfront in `pendingRunnerNames` to prevent collisions,
+    /// then runners are registered sequentially.
+    ///
+    /// - Parameters:
+    ///   - baseName: The base name for the runners
+    ///   - repo: GitHub repository in "owner/repo" format
+    ///   - labels: Labels to assign to each runner
+    ///   - count: Number of instances to create (must be >= 1)
+    ///   - isolationMode: Optional isolation mode override
+    ///   - enableGUI: Whether to enable GUI access
+    ///   - onProgress: Called after each runner is created with (completed, total)
+    /// - Throws: RunnerError if validation or setup fails for any runner
+    func addRunners(
+        baseName: String,
+        repo: String,
+        labels: [String],
+        count: Int,
+        isolationMode: IsolationMode? = nil,
+        enableGUI: Bool = false,
+        onProgress: ((Int, Int) -> Void)? = nil
+    ) async throws {
+        guard count >= 1 else { return }
+
+        // Single runner: use exact name (current behavior)
+        if count == 1 {
+            try await addRunner(
+                name: baseName,
+                repo: repo,
+                labels: labels,
+                isolationMode: isolationMode,
+                enableGUI: enableGUI
+            )
+            onProgress?(1, 1)
+            return
+        }
+
+        // Multiple runners: generate numbered names and reserve them upfront
+        var names: [String] = []
+        for i in 1...count {
+            let candidate = "\(baseName)-\(i)"
+            let allNames = Set(runners.map(\.name)).union(pendingRunnerNames)
+            if allNames.contains(candidate) {
+                // If the numbered name collides, find the next available
+                let name = generateUniqueRunnerName(base: baseName)
+                names.append(name)
+                pendingRunnerNames.insert(name)
+            } else {
+                names.append(candidate)
+                pendingRunnerNames.insert(candidate)
+            }
+        }
+
+        // Register runners sequentially, releasing pending names as we go
+        var errors: [(name: String, error: Error)] = []
+        for (index, name) in names.enumerated() {
+            do {
+                try await addRunner(
+                    name: name,
+                    repo: repo,
+                    labels: labels,
+                    isolationMode: isolationMode,
+                    enableGUI: enableGUI
+                )
+            } catch {
+                errors.append((name: name, error: error))
+            }
+            pendingRunnerNames.remove(name)
+            onProgress?(index + 1, count)
+        }
+
+        if !errors.isEmpty {
+            let message = errors.map { "\($0.name): \($0.error.localizedDescription)" }.joined(separator: "; ")
+            throw RunnerError.bulkCreationPartialFailure(succeeded: count - errors.count, failed: errors.count, details: message)
+        }
     }
 
     // MARK: - Private Helpers
@@ -609,6 +734,7 @@ enum RunnerError: LocalizedError {
     case invalidRepo
     case startFailed
     case containerServiceNotAvailable
+    case bulkCreationPartialFailure(succeeded: Int, failed: Int, details: String)
 
     var errorDescription: String? {
         switch self {
@@ -619,6 +745,8 @@ enum RunnerError: LocalizedError {
         case .startFailed: return "Failed to start runner process"
         case .containerServiceNotAvailable:
             return "Container isolation requires macOS 26.0+ and is not available on this system"
+        case .bulkCreationPartialFailure(let succeeded, let failed, let details):
+            return "Bulk creation: \(succeeded) succeeded, \(failed) failed (\(details))"
         }
     }
 }

--- a/Sources/Views/AddRunnerView.swift
+++ b/Sources/Views/AddRunnerView.swift
@@ -13,7 +13,9 @@ struct AddRunnerView: View {
     @State private var repoSearchText = ""
     @State private var isLoadingRepos = false
     @State private var showRepoPicker = false
+    @State private var numberOfInstances = 1
     @State private var isAdding = false
+    @State private var addingProgress: (current: Int, total: Int)?
     @State private var errorMessage: String?
 
     enum IsolationSelection: String, CaseIterable, Identifiable {
@@ -212,6 +214,38 @@ struct AddRunnerView: View {
                         }
                     }
 
+                    // Number of Instances
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Number of Instances")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+
+                        HStack {
+                            Stepper(value: $numberOfInstances, in: 1...20) {
+                                Text("\(numberOfInstances)")
+                                    .font(.system(.body, design: .monospaced))
+                                    .frame(minWidth: 24, alignment: .center)
+                            }
+                        }
+
+                        if numberOfInstances > 1 {
+                            let baseName = name.isEmpty ? "mac-runner" : name
+                            VStack(alignment: .leading, spacing: 2) {
+                                ForEach(1...min(numberOfInstances, 5), id: \.self) { i in
+                                    Text("\(baseName)-\(i)")
+                                        .font(.system(.caption, design: .monospaced))
+                                        .foregroundColor(.secondary)
+                                }
+                                if numberOfInstances > 5 {
+                                    Text("... and \(numberOfInstances - 5) more")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                            .padding(.top, 2)
+                        }
+                    }
+
                     if let error = errorMessage {
                         Text(error)
                             .foregroundColor(.red)
@@ -233,12 +267,17 @@ struct AddRunnerView: View {
                 Spacer()
 
                 if isAdding {
+                    if let progress = addingProgress, progress.total > 1 {
+                        Text("\(progress.current)/\(progress.total)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                     ProgressView()
                         .controlSize(.small)
                         .padding(.trailing, 8)
                 }
 
-                Button("Add Runner") {
+                Button(numberOfInstances > 1 ? "Add \(numberOfInstances) Runners" : "Add Runner") {
                     Task { await addRunner() }
                 }
                 .buttonStyle(.borderedProminent)
@@ -247,7 +286,7 @@ struct AddRunnerView: View {
             }
             .padding()
         }
-        .frame(width: 400, height: 480)
+        .frame(width: 400, height: 560)
     }
 
     private func loadRepos() async {
@@ -275,10 +314,14 @@ struct AddRunnerView: View {
 
     private func addRunner() async {
         isAdding = true
-        defer { isAdding = false }
+        addingProgress = nil
+        defer {
+            isAdding = false
+            addingProgress = nil
+        }
         errorMessage = nil
 
-        let runnerName = name.isEmpty
+        let baseName = name.isEmpty
             ? "mac-runner-\(Int.random(in: 1000...9999))"
             : name
 
@@ -288,12 +331,16 @@ struct AddRunnerView: View {
             .filter { !$0.isEmpty }
 
         do {
-            try await runnerManager.addRunner(
-                name: runnerName,
+            try await runnerManager.addRunners(
+                baseName: baseName,
                 repo: repo,
                 labels: labels.isEmpty ? ["macos"] : labels,
+                count: numberOfInstances,
                 isolationMode: selectedIsolation.isolationMode,
-                enableGUI: enableGUI
+                enableGUI: enableGUI,
+                onProgress: { current, total in
+                    addingProgress = (current: current, total: total)
+                }
             )
             dismiss()
         } catch {

--- a/Tests/MacRunnerTests/RunnerNamingTests.swift
+++ b/Tests/MacRunnerTests/RunnerNamingTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import MacRunner
+
+/// Unit tests for runner name generation — baseName stripping and unique name logic.
+final class RunnerNamingTests: XCTestCase {
+
+    // MARK: - baseName(from:)
+
+    func testBaseNameStripsNumericSuffix() {
+        XCTAssertEqual(RunnerManager.baseName(from: "my-runner-2"), "my-runner")
+        XCTAssertEqual(RunnerManager.baseName(from: "my-runner-99"), "my-runner")
+        XCTAssertEqual(RunnerManager.baseName(from: "runner-1"), "runner")
+    }
+
+    func testBaseNamePreservesNameWithoutSuffix() {
+        XCTAssertEqual(RunnerManager.baseName(from: "my-runner"), "my-runner")
+        XCTAssertEqual(RunnerManager.baseName(from: "runner"), "runner")
+    }
+
+    func testBaseNamePreservesNonNumericSuffix() {
+        XCTAssertEqual(RunnerManager.baseName(from: "my-runner-arm"), "my-runner-arm")
+        XCTAssertEqual(RunnerManager.baseName(from: "my-runner-abc"), "my-runner-abc")
+    }
+
+    func testBaseNameStripsOnlyLastNumericSegment() {
+        // "my-runner-2-3" → strip "-3" → "my-runner-2"
+        XCTAssertEqual(RunnerManager.baseName(from: "my-runner-2-3"), "my-runner-2")
+    }
+
+    func testBaseNameWithNoDash() {
+        XCTAssertEqual(RunnerManager.baseName(from: "runner"), "runner")
+    }
+
+    func testBaseNameWithEmptyNumericSuffix() {
+        // Trailing dash with nothing after it — not a numeric suffix
+        XCTAssertEqual(RunnerManager.baseName(from: "runner-"), "runner-")
+    }
+}


### PR DESCRIPTION
## Summary
- **Bug fix**: Resolves the race condition in `duplicateRunner()` where rapid duplicate clicks both generate the same name (e.g. two `runner-2`s). Names are now reserved in a `pendingRunnerNames` set before async work begins.
- **Bug fix**: Duplicating `runner-2` now correctly yields `runner-3` instead of `runner-2-2` — trailing `-N` numeric suffixes are stripped to find the base name.
- **Feature**: Adds bulk runner creation — the Add Runner form now includes a "Number of Instances" stepper (1–20) with a live name preview, sequential registration, and progress indicator.

## Changes
- `RunnerManager.swift`: Added `pendingRunnerNames` set, `baseName(from:)` helper, `generateUniqueRunnerName(base:)`, refactored `duplicateRunner()`, added `addRunners()` bulk method, added `bulkCreationPartialFailure` error case
- `AddRunnerView.swift`: Added instance count stepper with name preview, bulk progress indicator, dynamic button text
- `RunnerNamingTests.swift`: Unit tests for `baseName(from:)` suffix stripping

## Test plan
- [ ] Verify `baseName` unit tests pass (`swift test`)
- [ ] Manually test: add runner, duplicate it twice rapidly — should get `-2` and `-3`, not two `-2`s
- [ ] Manually test: duplicate `runner-2` — should create `runner-3`, not `runner-2-2`
- [ ] Manually test: Add Runner with instance count = 3 — creates `name-1`, `name-2`, `name-3`
- [ ] Manually test: Add Runner with instance count = 1 — unchanged behavior (no suffix)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Create multiple runner instances simultaneously with a configurable count (1-20)
  * Auto-generated unique names for bulk runner operations
  * Real-time progress tracking during multi-instance creation

* **Bug Fixes**
  * Improved error handling and reporting for partial failures during bulk creation

* **Tests**
  * Added test coverage for runner naming system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->