### PR TITLE
feat: auto-provision runner toolchains

### DIFF
--- a/Sources/Models/Runner.swift
+++ b/Sources/Models/Runner.swift
@@ -183,6 +183,7 @@ struct AppSettings: Codable, Sendable {
     var pauseOnBattery: Bool
     var quietHours: QuietHours?
     var isolationMode: IsolationMode
+    var tools: ToolProvisioningSettings
     var autoCheckForUpdates: Bool
     var autoRestartEnabled: Bool
     var autoRestartMaxRetries: Int
@@ -193,6 +194,7 @@ struct AppSettings: Codable, Sendable {
         pauseOnBattery: false,
         quietHours: nil,
         isolationMode: .none,
+        tools: .default,
         autoCheckForUpdates: true,
         autoRestartEnabled: true,
         autoRestartMaxRetries: 5,
@@ -204,6 +206,7 @@ struct AppSettings: Codable, Sendable {
         pauseOnBattery: Bool = false,
         quietHours: QuietHours? = nil,
         isolationMode: IsolationMode = .none,
+        tools: ToolProvisioningSettings = .default,
         autoCheckForUpdates: Bool = true,
         autoRestartEnabled: Bool = true,
         autoRestartMaxRetries: Int = 5,
@@ -213,6 +216,7 @@ struct AppSettings: Codable, Sendable {
         self.pauseOnBattery = pauseOnBattery
         self.quietHours = quietHours
         self.isolationMode = isolationMode
+        self.tools = tools
         self.autoCheckForUpdates = autoCheckForUpdates
         self.autoRestartEnabled = autoRestartEnabled
         self.autoRestartMaxRetries = max(1, autoRestartMaxRetries)
@@ -225,12 +229,47 @@ struct AppSettings: Codable, Sendable {
         pauseOnBattery = try container.decodeIfPresent(Bool.self, forKey: .pauseOnBattery) ?? false
         quietHours = try container.decodeIfPresent(QuietHours.self, forKey: .quietHours)
         isolationMode = try container.decodeIfPresent(IsolationMode.self, forKey: .isolationMode) ?? .none
+        tools = try container.decodeIfPresent(ToolProvisioningSettings.self, forKey: .tools) ?? .default
         autoCheckForUpdates = try container.decodeIfPresent(Bool.self, forKey: .autoCheckForUpdates) ?? true
         autoRestartEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoRestartEnabled) ?? true
         autoRestartMaxRetries = max(1, try container.decodeIfPresent(Int.self, forKey: .autoRestartMaxRetries) ?? 5)
         openFileLimit = ResourceLimits.normalizedOpenFileLimit(
             try container.decodeIfPresent(Int.self, forKey: .openFileLimit)
         ) ?? ResourceLimits.defaultOpenFileLimit
+    }
+}
+
+struct ToolProvisioningSettings: Codable, Sendable, Equatable {
+    var extraPackages: [String]
+
+    static let `default` = ToolProvisioningSettings(extraPackages: [])
+
+    init(extraPackages: [String] = []) {
+        self.extraPackages = Self.normalize(extraPackages)
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        extraPackages = Self.normalize(
+            try container.decodeIfPresent([String].self, forKey: .extraPackages) ?? []
+        )
+    }
+
+    private static func normalize(_ packages: [String]) -> [String] {
+        let allowedCharacters = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789@+._-")
+
+        Array(
+            Set(
+                packages.map {
+                    $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                        .lowercased()
+                }
+                .filter {
+                    !$0.isEmpty && $0.unicodeScalars.allSatisfy { allowedCharacters.contains($0) }
+                }
+            )
+        )
+        .sorted()
     }
 }
 

--- a/Sources/Models/Runner.swift
+++ b/Sources/Models/Runner.swift
@@ -258,7 +258,7 @@ struct ToolProvisioningSettings: Codable, Sendable, Equatable {
     private static func normalize(_ packages: [String]) -> [String] {
         let allowedCharacters = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789@+._-")
 
-        Array(
+        return Array(
             Set(
                 packages.map {
                     $0.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/Services/GHCLIService.swift
+++ b/Sources/Services/GHCLIService.swift
@@ -19,8 +19,22 @@ final class GHCLIService: Sendable {
 
     private let ghPath: String
 
-    init(ghPath: String = "/opt/homebrew/bin/gh") {
-        self.ghPath = ghPath
+    init(
+        ghPath: String? = nil,
+        fileExists: @escaping @Sendable (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) {
+        self.ghPath = ghPath ?? Self.detectExecutablePath(fileExists: fileExists)
+    }
+
+    static func detectExecutablePath(
+        fileExists: @escaping @Sendable (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> String {
+        let candidates = [
+            "/opt/homebrew/bin/gh",
+            "/usr/local/bin/gh"
+        ]
+
+        return candidates.first(where: fileExists) ?? "/opt/homebrew/bin/gh"
     }
 
     // MARK: - Private Helpers
@@ -142,6 +156,22 @@ final class GHCLIService: Sendable {
     func validateRepo(_ repo: String) async throws -> Bool {
         let result = try await runGH(["api", "repos/\(repo)"])
         return result.exitCode == 0
+    }
+
+    func repositoryRootEntries(for repo: String) async throws -> Set<String> {
+        let result = try await runGH([
+            "api", "repos/\(repo)/contents",
+            "--jq", ".[].name"
+        ])
+        guard result.exitCode == 0 else {
+            throw GHError.apiFailed("Failed to inspect repository contents: \(result.stderr)")
+        }
+
+        let entries = result.stdout
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return Set(entries)
     }
 
     // MARK: - Runners

--- a/Sources/Services/RunnerManager.swift
+++ b/Sources/Services/RunnerManager.swift
@@ -27,6 +27,7 @@ class RunnerManager: ObservableObject {
     private let configService = ConfigService()
     private let ghService = GHCLIService.shared
     private let isolationService = UserIsolationService.shared
+    private let toolProvisioningService = ToolProvisioningService()
     private let processManager = ProcessManager()
     private let pidManager = PIDFileManager()
     private let updateChecker = UpdateChecker()
@@ -394,15 +395,6 @@ class RunnerManager: ObservableObject {
         isLoading = true
         defer { isLoading = false }
 
-        // Validate repo access via gh CLI
-        guard try await ghService.validateRepo(repo) else {
-            throw RunnerError.invalidRepo
-        }
-
-        // Get registration token from GitHub via gh CLI
-        let registrationToken = try await ghService.getRegistrationToken(for: repo)
-
-        // Create runner with optional isolation mode override and GUI access setting
         let runner = Runner(
             name: name,
             repo: repo,
@@ -414,8 +406,23 @@ class RunnerManager: ObservableObject {
             openFileLimit: openFileLimit
         )
 
-        // Use per-runner isolation mode if specified, otherwise use global setting
         let effectiveIsolation = runner.effectiveIsolationMode(global: currentSettings.isolationMode)
+
+        try await toolProvisioningService.ensureGitHubCLI(isolation: effectiveIsolation)
+
+        // Validate repo access via gh CLI
+        guard try await ghService.validateRepo(repo) else {
+            throw RunnerError.invalidRepo
+        }
+
+        try await toolProvisioningService.provisionTools(
+            for: repo,
+            settings: currentSettings.tools,
+            isolation: effectiveIsolation
+        )
+
+        // Get registration token from GitHub via gh CLI
+        let registrationToken = try await ghService.getRegistrationToken(for: repo)
 
         // Download, configure, and install runner
         try await RunnerInstaller.shared.setupRunner(

--- a/Sources/Services/ToolProvisioningService.swift
+++ b/Sources/Services/ToolProvisioningService.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+enum ToolProvisioningError: LocalizedError, Equatable {
+    case homebrewNotFound
+    case installFailed(package: String, output: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .homebrewNotFound:
+            return "Homebrew was not found in a standard install location."
+        case .installFailed(let package, let output):
+            let trimmedOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedOutput.isEmpty {
+                return "Failed to install tool: \(package)"
+            }
+            return "Failed to install tool \(package): \(trimmedOutput)"
+        }
+    }
+}
+
+struct ToolProvisioningPlan: Sendable, Equatable {
+    let packages: [String]
+}
+
+struct ToolProvisioningService: Sendable {
+    typealias FetchRepositoryRootEntries = @Sendable (String) async throws -> Set<String>
+    typealias FileExists = @Sendable (String) -> Bool
+    typealias RunCommand = @Sendable (String, [String]) async throws -> UpdateInstallerCommandResult
+
+    private let fetchRepositoryRootEntries: FetchRepositoryRootEntries
+    private let fileExists: FileExists
+    private let runCommand: RunCommand
+
+    init(
+        fetchRepositoryRootEntries: @escaping FetchRepositoryRootEntries = { repo in
+            try await GHCLIService.shared.repositoryRootEntries(for: repo)
+        },
+        fileExists: @escaping FileExists = { FileManager.default.isExecutableFile(atPath: $0) },
+        runCommand: @escaping RunCommand = Self.liveRunCommand
+    ) {
+        self.fetchRepositoryRootEntries = fetchRepositoryRootEntries
+        self.fileExists = fileExists
+        self.runCommand = runCommand
+    }
+
+    func ensureGitHubCLI(isolation: IsolationMode) async throws {
+        guard isolation != .container else { return }
+        try await ensureInstalled(packages: ["gh"])
+    }
+
+    func provisionTools(
+        for repo: String,
+        settings: ToolProvisioningSettings,
+        isolation: IsolationMode
+    ) async throws {
+        guard isolation != .container else { return }
+
+        let rootEntries = try await fetchRepositoryRootEntries(repo)
+        let plan = Self.plan(rootEntries: rootEntries, settings: settings)
+
+        try await ensureInstalled(packages: plan.packages)
+    }
+
+    private func ensureInstalled(packages: [String]) async throws {
+        guard !packages.isEmpty else { return }
+
+        guard let brewExecutable = UpdateInstaller.brewExecutablePath(fileExists: fileExists) else {
+            throw ToolProvisioningError.homebrewNotFound
+        }
+
+        for package in packages {
+            guard !(try await isInstalled(package: package)) else { continue }
+
+            let result = try await runCommand(brewExecutable, ["install", package])
+            guard result.terminationStatus == 0 else {
+                throw ToolProvisioningError.installFailed(package: package, output: result.output)
+            }
+        }
+    }
+
+    static func plan(rootEntries: Set<String>, settings: ToolProvisioningSettings) -> ToolProvisioningPlan {
+        let lowercasedEntries = Set(rootEntries.map { $0.lowercased() })
+        var packages = Set(["gh"])
+
+        for detector in ToolDetector.allCases where detector.matches(rootEntries: lowercasedEntries) {
+            packages.insert(detector.packageName)
+        }
+
+        for package in settings.extraPackages {
+            packages.insert(package)
+        }
+
+        return ToolProvisioningPlan(packages: packages.sorted())
+    }
+
+    private func isInstalled(package: String) async throws -> Bool {
+        for candidate in Self.executableCandidates(for: package) where fileExists(candidate) {
+            return true
+        }
+
+        let result = try await runCommand("/bin/bash", ["-lc", "command -v \(package)"])
+        return result.terminationStatus == 0 && !result.output.isEmpty
+    }
+
+    private static func executableCandidates(for package: String) -> [String] {
+        switch package {
+        case "gh":
+            return ["/opt/homebrew/bin/gh", "/usr/local/bin/gh"]
+        case "node":
+            return ["/opt/homebrew/bin/node", "/usr/local/bin/node"]
+        case "python":
+            return ["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"]
+        case "go":
+            return ["/opt/homebrew/bin/go", "/usr/local/bin/go"]
+        case "ruby":
+            return ["/opt/homebrew/bin/ruby", "/usr/local/bin/ruby", "/usr/bin/ruby"]
+        case "rust":
+            return ["/opt/homebrew/bin/rustc", "/usr/local/bin/rustc"]
+        default:
+            return []
+        }
+    }
+
+    private static func liveRunCommand(executable: String, arguments: [String]) async throws -> UpdateInstallerCommandResult {
+        try await Task.detached(priority: .userInitiated) {
+            let result = try ProcessExecutor.run(executable, arguments: arguments)
+            return UpdateInstallerCommandResult(
+                terminationStatus: result.terminationStatus,
+                output: result.output
+            )
+        }.value
+    }
+}
+
+private enum ToolDetector: CaseIterable {
+    case node
+    case python
+    case go
+    case ruby
+    case rust
+
+    var packageName: String {
+        switch self {
+        case .node:
+            return "node"
+        case .python:
+            return "python"
+        case .go:
+            return "go"
+        case .ruby:
+            return "ruby"
+        case .rust:
+            return "rust"
+        }
+    }
+
+    func matches(rootEntries: Set<String>) -> Bool {
+        switch self {
+        case .node:
+            return !rootEntries.isDisjoint(with: ["package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock", "bun.lock", "bun.lockb", ".nvmrc"])
+        case .python:
+            return !rootEntries.isDisjoint(with: ["requirements.txt", "pyproject.toml", "pipfile", "poetry.lock", "uv.lock", ".python-version"])
+        case .go:
+            return rootEntries.contains("go.mod")
+        case .ruby:
+            return !rootEntries.isDisjoint(with: ["gemfile", ".ruby-version"])
+        case .rust:
+            return rootEntries.contains("cargo.toml")
+        }
+    }
+}

--- a/Sources/Views/MenuBarView.swift
+++ b/Sources/Views/MenuBarView.swift
@@ -465,6 +465,32 @@ struct SettingsView: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Extra CI Tools")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    TextField("jq, pnpm, ...", text: Binding(
+                        get: { runnerManager.currentSettings.tools.extraPackages.joined(separator: ", ") },
+                        set: { newValue in
+                            var settings = runnerManager.currentSettings
+                            settings.tools = ToolProvisioningSettings(
+                                extraPackages: newValue
+                                    .components(separatedBy: ",")
+                                    .map {
+                                        $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                                    }
+                            )
+                            runnerManager.updateSettings(settings)
+                        }
+                    ))
+                    .textFieldStyle(.roundedBorder)
+
+                    Text("New runners always provision gh, detect common language toolchains from repo metadata, and install any extra Homebrew packages listed here.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
                 Spacer()
             }
             .padding()

--- a/Tests/MacRunnerTests/MacRunnerTests.swift
+++ b/Tests/MacRunnerTests/MacRunnerTests.swift
@@ -186,4 +186,54 @@ final class MacRunnerTests: XCTestCase {
             ConfigService.invokingUser(effectiveUserID: 501, environment: ["SUDO_USER": "peyton"])
         )
     }
+
+    func testToolProvisioningPlanIncludesAlwaysOnDetectedAndConfiguredPackages() {
+        let plan = ToolProvisioningService.plan(
+            rootEntries: ["package.json", "requirements.txt", "Cargo.toml"],
+            settings: ToolProvisioningSettings(extraPackages: ["jq", "gh", "jq"])
+        )
+
+        XCTAssertEqual(plan.packages, ["gh", "jq", "node", "python", "rust"])
+    }
+
+    func testToolProvisioningPlanHandlesCaseInsensitiveRepositoryMetadata() {
+        let plan = ToolProvisioningService.plan(
+            rootEntries: ["Gemfile", "GO.MOD", "PyProject.toml"],
+            settings: .default
+        )
+
+        XCTAssertEqual(plan.packages, ["gh", "go", "python", "ruby"])
+    }
+
+    func testAppSettingsDefaultsToolProvisioningConfigWhenMissing() throws {
+        let data = Data("""
+        {
+          "startOnLogin": true,
+          "isolationMode": {
+            "type": "none"
+          }
+        }
+        """.utf8)
+
+        let settings = try JSONDecoder().decode(AppSettings.self, from: data)
+
+        XCTAssertEqual(settings.tools, .default)
+    }
+
+    func testToolProvisioningSettingsNormalizesExtraPackages() {
+        let settings = ToolProvisioningSettings(extraPackages: [" jq ", "PNPM", "jq", "bad;rm", ""])
+
+        XCTAssertEqual(settings.extraPackages, ["jq", "pnpm"])
+    }
+
+    func testGHCLIServiceDetectExecutablePathPrefersAvailableStandardLocations() {
+        XCTAssertEqual(
+            GHCLIService.detectExecutablePath(fileExists: { $0 == "/usr/local/bin/gh" }),
+            "/usr/local/bin/gh"
+        )
+        XCTAssertEqual(
+            GHCLIService.detectExecutablePath(fileExists: { _ in false }),
+            "/opt/homebrew/bin/gh"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- auto-provision `gh` before repo validation, then detect common language toolchains from root repo metadata when creating new runners
- add a persisted `settings.tools.extraPackages` config plus settings UI so users can request extra Homebrew packages for future runners
- cover package planning, config decoding, settings normalization, and `gh` path detection with focused unit tests

## Testing
- `git diff --check`
- `swift test` *(not runnable in this container: `swift: command not found`)*

## Notes
- this PR provisions tools for non-isolated and dedicated-user runners; container-mode provisioning is intentionally left for follow-up work
