### PR TITLE
fix: handle expired gh auth during runner start

### DIFF
--- a/Sources/Services/CLIHandler.swift
+++ b/Sources/Services/CLIHandler.swift
@@ -247,9 +247,9 @@ enum CLIHandler {
         }
 
         // Check auth first
-        let authenticated = await GHCLIService.shared.checkAuth()
-        guard authenticated else {
-            print("Error: not authenticated with GitHub. Run: gh auth login")
+        let authState = await GHCLIService.shared.validateAuth()
+        guard authState.isAuthenticated else {
+            print("Error: \(authState.recoveryMessage)")
             return
         }
 

--- a/Sources/Services/GHCLIService.swift
+++ b/Sources/Services/GHCLIService.swift
@@ -14,6 +14,36 @@ struct ProcessResult: Sendable {
     let stderr: String
 }
 
+struct GitHubAuthState: Sendable, Equatable {
+    let isAuthenticated: Bool
+    let statusMessage: String
+    let recoveryMessage: String
+
+    static func fromProcessResult(exitCode: Int32, stdout: String, stderr: String) -> GitHubAuthState {
+        let detail = stderr.isEmpty ? stdout : stderr
+        let trimmedDetail = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if exitCode == 0 {
+            return GitHubAuthState(
+                isAuthenticated: true,
+                statusMessage: trimmedDetail.isEmpty ? "Authenticated with GitHub CLI." : trimmedDetail,
+                recoveryMessage: ""
+            )
+        }
+
+        let recoveryPrefix = "GitHub authentication expired or is invalid. Run: gh auth login"
+        let recoveryMessage = trimmedDetail.isEmpty
+            ? recoveryPrefix
+            : "\(recoveryPrefix)\n\(trimmedDetail)"
+
+        return GitHubAuthState(
+            isAuthenticated: false,
+            statusMessage: trimmedDetail.isEmpty ? "gh CLI not found or not authenticated" : trimmedDetail,
+            recoveryMessage: recoveryMessage
+        )
+    }
+}
+
 final class GHCLIService: Sendable {
     static let shared = GHCLIService()
 
@@ -73,11 +103,24 @@ final class GHCLIService: Sendable {
 
     // MARK: - Auth
 
-    func checkAuth() async -> Bool {
+    func validateAuth() async -> GitHubAuthState {
         guard let result = try? await runGH(["auth", "status"]) else {
-            return false
+            return GitHubAuthState(
+                isAuthenticated: false,
+                statusMessage: "gh CLI not found or not authenticated",
+                recoveryMessage: "GitHub authentication expired or is invalid. Run: gh auth login"
+            )
         }
-        return result.exitCode == 0
+
+        return GitHubAuthState.fromProcessResult(
+            exitCode: result.exitCode,
+            stdout: result.stdout,
+            stderr: result.stderr
+        )
+    }
+
+    func checkAuth() async -> Bool {
+        await validateAuth().isAuthenticated
     }
 
     func openLogin() async throws {
@@ -88,13 +131,8 @@ final class GHCLIService: Sendable {
     }
 
     func authStatus() async -> String {
-        guard let result = try? await runGH(["auth", "status"]) else {
-            return "gh CLI not found or not authenticated"
-        }
-        // gh auth status prints to stderr
-        return result.exitCode == 0
-            ? (result.stderr.isEmpty ? result.stdout : result.stderr)
-            : "Not authenticated. Run: gh auth login"
+        let state = await validateAuth()
+        return state.isAuthenticated ? state.statusMessage : state.recoveryMessage
     }
 
     // MARK: - Repos

--- a/Sources/Services/RunnerManager.swift
+++ b/Sources/Services/RunnerManager.swift
@@ -23,6 +23,7 @@ class RunnerManager: ObservableObject {
     @Published private(set) var isCheckingForUpdates = false
     @Published private(set) var isInstallingUpdate = false
     @Published private(set) var updateStatusMessage = UpdateStatusMessages.defaultAutomaticChecks
+    @Published private(set) var gitHubAuthIssue: String?
 
     private let configService = ConfigService()
     private let ghService = GHCLIService.shared
@@ -76,6 +77,7 @@ class RunnerManager: ObservableObject {
             : nil
         refreshUpdateStatusMessage()
         initializeContainerService()
+        Task { await refreshGitHubAuthStatus() }
 
         // Before reconciling, capture runners that were running but whose
         // processes are no longer alive — these need auto-restart after launch.
@@ -268,6 +270,11 @@ class RunnerManager: ObservableObject {
         }
     }
 
+    func refreshGitHubAuthStatus() async {
+        let authState = await ghService.validateAuth()
+        gitHubAuthIssue = authState.isAuthenticated ? nil : authState.recoveryMessage
+    }
+
     func openUpdate() {
         guard let availableUpdate else { return }
         NSWorkspace.shared.open(availableUpdate.releaseURL)
@@ -410,6 +417,8 @@ class RunnerManager: ObservableObject {
 
         try await toolProvisioningService.ensureGitHubCLI(isolation: effectiveIsolation)
 
+        try await validateGitHubAuth(for: runner, operation: "add runner")
+
         // Validate repo access via gh CLI
         guard try await ghService.validateRepo(repo) else {
             throw RunnerError.invalidRepo
@@ -510,9 +519,11 @@ class RunnerManager: ObservableObject {
 
         // Get runner directory
         let runnerDir = try RunnerDirectory.path(for: id, isolation: isolation)
+        let needsRunnerSetup = !FileManager.default.fileExists(atPath: "\(runnerDir)/run.sh")
 
         // Ensure runner binary is downloaded and configured
-        if !FileManager.default.fileExists(atPath: "\(runnerDir)/run.sh") {
+        if needsRunnerSetup {
+            try await validateGitHubAuth(for: runner, operation: "start runner")
             let registrationToken = try await ghService.getRegistrationToken(for: runner.repo)
             try await RunnerInstaller.shared.setupRunner(
                 repo: runner.repo,
@@ -529,6 +540,9 @@ class RunnerManager: ObservableObject {
 
         // Container isolation requires special handling
         if case .container = isolation {
+            if !needsRunnerSetup {
+                try await validateGitHubAuth(for: runner, operation: "start runner")
+            }
             // Container-based isolation (macOS 26+)
             #if canImport(Containerization)
             if #available(macOS 26.0, *) {
@@ -1093,6 +1107,21 @@ class RunnerManager: ObservableObject {
         let attempts = restartAttemptHistory[id, default: []].filter { $0 >= cutoff }
         restartAttemptHistory[id] = attempts
         return attempts
+    }
+
+    private func validateGitHubAuth(for runner: Runner, operation: String) async throws {
+        let authState = await ghService.validateAuth()
+        guard authState.isAuthenticated else {
+            gitHubAuthIssue = authState.recoveryMessage
+            error = authState.recoveryMessage
+            logRunnerEvent(
+                for: runner,
+                message: "GitHub auth check failed during \(operation): \(authState.recoveryMessage)"
+            )
+            throw GHError.authFailed(authState.recoveryMessage)
+        }
+
+        gitHubAuthIssue = nil
     }
 
     private func cancelScheduledRestarts(clearHistory: Bool) {

--- a/Sources/Views/MenuBarView.swift
+++ b/Sources/Views/MenuBarView.swift
@@ -141,6 +141,13 @@ struct MenuBarView: View {
 
     private var footerButtons: some View {
         VStack(alignment: .leading, spacing: 10) {
+            if let gitHubAuthIssue = runnerManager.gitHubAuthIssue {
+                Text(gitHubAuthIssue)
+                    .font(.caption2)
+                    .foregroundColor(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             if let update = runnerManager.availableUpdate {
                 Button(action: {
                     Task {
@@ -579,6 +586,7 @@ struct SettingsView: View {
     private func checkAuth() async {
         isAuthenticated = await GHCLIService.shared.checkAuth()
         authStatusText = await GHCLIService.shared.authStatus()
+        await runnerManager.refreshGitHubAuthStatus()
     }
 
     private func login() async {

--- a/Tests/MacRunnerTests/MacRunnerTests.swift
+++ b/Tests/MacRunnerTests/MacRunnerTests.swift
@@ -236,4 +236,39 @@ final class MacRunnerTests: XCTestCase {
             "/opt/homebrew/bin/gh"
         )
     }
+
+    func testGitHubAuthStateUsesDetailedAuthenticatedStatusOutput() {
+        let state = GitHubAuthState.fromProcessResult(
+            exitCode: 0,
+            stdout: "",
+            stderr: "Logged in to github.com as peyton"
+        )
+
+        XCTAssertTrue(state.isAuthenticated)
+        XCTAssertEqual(state.statusMessage, "Logged in to github.com as peyton")
+        XCTAssertEqual(state.recoveryMessage, "")
+    }
+
+    func testGitHubAuthStateBuildsActionableRecoveryMessage() {
+        let state = GitHubAuthState.fromProcessResult(
+            exitCode: 1,
+            stdout: "",
+            stderr: "Token in keychain has expired"
+        )
+
+        XCTAssertFalse(state.isAuthenticated)
+        XCTAssertEqual(state.statusMessage, "Token in keychain has expired")
+        XCTAssertEqual(
+            state.recoveryMessage,
+            "GitHub authentication expired or is invalid. Run: gh auth login\nToken in keychain has expired"
+        )
+    }
+
+    func testGitHubAuthStateFallsBackToGenericRecoveryMessageWithoutDetails() {
+        let state = GitHubAuthState.fromProcessResult(exitCode: 1, stdout: "", stderr: "")
+
+        XCTAssertFalse(state.isAuthenticated)
+        XCTAssertEqual(state.statusMessage, "gh CLI not found or not authenticated")
+        XCTAssertEqual(state.recoveryMessage, "GitHub authentication expired or is invalid. Run: gh auth login")
+    }
 }


### PR DESCRIPTION
## Summary
- validate `gh auth status` before runner registration work so add/start/restart paths fail with explicit recovery guidance instead of silently breaking when credentials expire
- surface the auth failure in the menubar footer and refresh that UI state when settings re-check GitHub auth
- add focused tests for the new auth-state parsing and recovery messaging

## Testing
- `git diff --check`
- `swift test` *(not runnable in this container: `swift: command not found`)*

## Notes
- this blocks restart loops caused by expired `gh` auth by marking the runner with an actionable auth failure instead of repeatedly retrying blind


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub authentication status is now monitored and refreshed on app startup
  * Authentication issues are displayed in the menu bar when problems are detected

* **Bug Fixes**
  * Enhanced error messaging for GitHub authentication failures with specific, actionable recovery guidance
  * Authentication validation now occurs at critical operation points for improved reliability

* **Tests**
  * Added test coverage for authentication state detection and error message generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->