### PR TITLE
feat: open active job runs from the menubar

### DIFF
--- a/Sources/Services/RunnerManager.swift
+++ b/Sources/Services/RunnerManager.swift
@@ -319,6 +319,27 @@ class RunnerManager: ObservableObject {
         }
     }
 
+    func currentWorkflowJob(for runnerID: UUID) -> WorkflowJobSummary? {
+        activeWorkflowJobs[runnerID]
+    }
+
+    func openCurrentWorkflowRun(for runnerID: UUID) {
+        guard let runURL = Self.currentWorkflowRunURL(from: activeWorkflowJobs[runnerID]) else {
+            return
+        }
+
+        NSWorkspace.shared.open(runURL)
+    }
+
+    static func currentWorkflowRunURL(from job: WorkflowJobSummary?) -> URL? {
+        job?.run.htmlURL
+    }
+
+    static func currentWorkflowDisplayName(from job: WorkflowJobSummary?) -> String? {
+        guard let job else { return nil }
+        return job.run.name.isEmpty ? job.name : job.run.name
+    }
+
     private func refreshUpdateStatusMessage() {
         if let availableUpdate {
             updateStatusMessage = "Version \(availableUpdate.latestVersion) is available."

--- a/Sources/Services/RunnerManager.swift
+++ b/Sources/Services/RunnerManager.swift
@@ -331,11 +331,11 @@ class RunnerManager: ObservableObject {
         NSWorkspace.shared.open(runURL)
     }
 
-    static func currentWorkflowRunURL(from job: WorkflowJobSummary?) -> URL? {
+    nonisolated static func currentWorkflowRunURL(from job: WorkflowJobSummary?) -> URL? {
         job?.run.htmlURL
     }
 
-    static func currentWorkflowDisplayName(from job: WorkflowJobSummary?) -> String? {
+    nonisolated static func currentWorkflowDisplayName(from job: WorkflowJobSummary?) -> String? {
         guard let job else { return nil }
         return job.run.name.isEmpty ? job.name : job.run.name
     }

--- a/Sources/Views/MenuBarView.swift
+++ b/Sources/Views/MenuBarView.swift
@@ -268,6 +268,25 @@ struct RunnerRow: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
 
+                if runner.status == .running,
+                   runner.busy,
+                   let currentJob = runnerManager.currentWorkflowJob(for: runner.id),
+                   let workflowName = RunnerManager.currentWorkflowDisplayName(from: currentJob) {
+                    Button(action: {
+                        runnerManager.openCurrentWorkflowRun(for: runner.id)
+                    }) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "link")
+                            Text("View \(workflowName)")
+                                .lineLimit(1)
+                        }
+                        .font(.caption2)
+                        .foregroundColor(.accentColor)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Open current GitHub Actions run")
+                }
+
                 HStack(spacing: 4) {
                     // Isolation mode indicator
                     if let mode = runner.isolationMode {
@@ -347,6 +366,11 @@ struct RunnerRow: View {
             if runner.status == .running {
                 Button("Stop") {
                     Task { try? await runnerManager.stopRunner(runner.id) }
+                }
+                if runner.busy, runnerManager.currentWorkflowJob(for: runner.id) != nil {
+                    Button("Open Current Job") {
+                        runnerManager.openCurrentWorkflowRun(for: runner.id)
+                    }
                 }
             } else {
                 Button("Start") {

--- a/Tests/MacRunnerTests/MacRunnerTests.swift
+++ b/Tests/MacRunnerTests/MacRunnerTests.swift
@@ -318,4 +318,36 @@ final class MacRunnerTests: XCTestCase {
         XCTAssertEqual(payload.body, "omniaura/mac-runner - Nightly (failure)")
         XCTAssertEqual(payload.runURL, run.htmlURL)
     }
+
+    func testRunnerManagerCurrentWorkflowHelpersPreferRunNameAndURL() {
+        let runURL = URL(string: "https://github.com/omniaura/mac-runner/actions/runs/42")!
+        let job = WorkflowJobSummary(
+            id: 8,
+            name: "test",
+            status: "in_progress",
+            conclusion: nil,
+            runnerName: "runner-1",
+            run: WorkflowRunSummary(id: 42, name: "Nightly", htmlURL: runURL)
+        )
+
+        XCTAssertEqual(RunnerManager.currentWorkflowDisplayName(from: job), "Nightly")
+        XCTAssertEqual(RunnerManager.currentWorkflowRunURL(from: job), runURL)
+    }
+
+    func testRunnerManagerCurrentWorkflowHelpersFallBackToJobName() {
+        let job = WorkflowJobSummary(
+            id: 9,
+            name: "integration",
+            status: "in_progress",
+            conclusion: nil,
+            runnerName: "runner-1",
+            run: WorkflowRunSummary(
+                id: 43,
+                name: "",
+                htmlURL: URL(string: "https://github.com/omniaura/mac-runner/actions/runs/43")!
+            )
+        )
+
+        XCTAssertEqual(RunnerManager.currentWorkflowDisplayName(from: job), "integration")
+    }
 }


### PR DESCRIPTION
## Summary
- add a direct menubar link for busy runners so operators can open the active GitHub Actions run from the EXECUTING state
- keep the active workflow job cache populated even when native notifications are disabled, since the menubar link should not depend on notification settings
- cover the new workflow-name and run-URL helpers with focused tests

## Testing
- `git diff --check`
- `swift test` *(not runnable in this container: `swift: command not found`)*

## Notes
- stacked on top of PR #68 because it reuses the workflow/job tracking introduced there
