### PR TITLE
fix: trigger semantic release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Instructions
+
+## Release Hygiene
+
+- Semantic-release only cuts releases from conventional commits. For any merged user-facing fix that did not include a `fix:` or `feat:` commit on the PR branch, open a follow-up PR with an empty conventional commit, for example `fix: trigger semantic release`, so the release pipeline publishes the change.


### PR DESCRIPTION
## Summary

- Add an empty `fix:` commit to trigger semantic-release after the settings pane fix merged.
- Add `AGENTS.md` guidance so agents remember to open a follow-up conventional-commit PR when a merged user-facing fix would otherwise miss semantic-release.

## Verification

- Not run: release-trigger/docs-only change.
