### PR TITLE
fix: runner PATH for Homebrew tools

### DIFF
--- a/Sources/Services/ProcessManager.swift
+++ b/Sources/Services/ProcessManager.swift
@@ -48,19 +48,9 @@ class ProcessManager {
             proc.standardOutput = logHandle
             proc.standardError = logHandle
 
-            // Configure environment for headless mode (remove GUI access)
-            if !enableGUI {
-                var env = ProcessInfo.processInfo.environment
-                // Remove GUI-related environment variables
-                env.removeValue(forKey: "DISPLAY")
-                env.removeValue(forKey: "WAYLAND_DISPLAY")
-                env.removeValue(forKey: "XDG_SESSION_TYPE")
-                env.removeValue(forKey: "XDG_RUNTIME_DIR")
-                // Explicitly mark as headless
-                env["CI"] = "true"
-                env["HEADLESS"] = "true"
-                proc.environment = env
-            }
+            let env = RunnerEnvironment.environment(enableGUI: enableGUI)
+            try RunnerEnvironment.writePathSnapshot(in: workingDirectory, environment: env)
+            proc.environment = env
 
             do {
                 try proc.run()

--- a/Sources/Services/RunnerEnvironment.swift
+++ b/Sources/Services/RunnerEnvironment.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum RunnerEnvironment {
+    private static let preferredPathEntries = [
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+    ]
+
+    private static let fallbackPath = "/usr/bin:/bin:/usr/sbin:/sbin"
+
+    static func environment(
+        from base: [String: String] = ProcessInfo.processInfo.environment,
+        enableGUI: Bool
+    ) -> [String: String] {
+        var environment = base
+        environment["PATH"] = normalizedPath(base["PATH"])
+
+        if !enableGUI {
+            environment.removeValue(forKey: "DISPLAY")
+            environment.removeValue(forKey: "WAYLAND_DISPLAY")
+            environment.removeValue(forKey: "XDG_SESSION_TYPE")
+            environment.removeValue(forKey: "XDG_RUNTIME_DIR")
+            environment["CI"] = "true"
+            environment["HEADLESS"] = "true"
+        }
+
+        return environment
+    }
+
+    static func normalizedPath(_ path: String?) -> String {
+        let sourcePath = path.flatMap { $0.isEmpty ? nil : $0 } ?? fallbackPath
+        let existingEntries = sourcePath
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .map(String.init)
+
+        var seen = Set<String>()
+        var entries: [String] = []
+
+        for entry in preferredPathEntries + existingEntries where seen.insert(entry).inserted {
+            entries.append(entry)
+        }
+
+        return entries.joined(separator: ":")
+    }
+
+    static func writePathSnapshot(
+        in runnerDirectory: String,
+        environment: [String: String] = Self.environment(enableGUI: false)
+    ) throws {
+        let path = normalizedPath(environment["PATH"])
+        let pathFile = URL(fileURLWithPath: runnerDirectory)
+            .appendingPathComponent(".path")
+
+        try (path + "\n").write(to: pathFile, atomically: true, encoding: .utf8)
+    }
+}

--- a/Sources/Services/RunnerInstaller.swift
+++ b/Sources/Services/RunnerInstaller.swift
@@ -96,6 +96,7 @@ class RunnerInstaller {
             process = Process()
             process.executableURL = URL(fileURLWithPath: "/bin/bash")
             process.arguments = ["-c", configCommand]
+            process.environment = RunnerEnvironment.environment(enableGUI: false)
 
         case .dedicatedUser(let username):
             // Run config.sh as the service user
@@ -113,6 +114,13 @@ class RunnerInstaller {
         guard process.terminationStatus == 0 else {
             let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
             throw InstallerError.configurationFailed(output)
+        }
+
+        if isolation == .none || isolation == .container {
+            try RunnerEnvironment.writePathSnapshot(
+                in: directory,
+                environment: RunnerEnvironment.environment(enableGUI: false)
+            )
         }
 
         print("Runner configured successfully")

--- a/Tests/MacRunnerTests/MacRunnerTests.swift
+++ b/Tests/MacRunnerTests/MacRunnerTests.swift
@@ -143,6 +143,69 @@ final class MacRunnerTests: XCTestCase {
         XCTAssertEqual(ResourceLimits.shellCommand("echo test", openFileLimit: 0), "echo test")
     }
 
+    func testRunnerEnvironmentPrependsHomebrewPathsToLaunchServicesPath() {
+        let path = RunnerEnvironment.normalizedPath("/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin")
+
+        XCTAssertTrue(path.hasPrefix("/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:"))
+        XCTAssertEqual(path.components(separatedBy: ":").filter { $0 == "/usr/local/bin" }.count, 1)
+    }
+
+    func testRunnerEnvironmentMarksHeadlessRuns() {
+        let environment = RunnerEnvironment.environment(
+            from: [
+                "PATH": "/usr/bin:/bin",
+                "DISPLAY": ":0",
+                "WAYLAND_DISPLAY": "wayland-0",
+                "XDG_SESSION_TYPE": "x11",
+                "XDG_RUNTIME_DIR": "/tmp/runtime",
+            ],
+            enableGUI: false
+        )
+
+        XCTAssertNil(environment["DISPLAY"])
+        XCTAssertNil(environment["WAYLAND_DISPLAY"])
+        XCTAssertNil(environment["XDG_SESSION_TYPE"])
+        XCTAssertNil(environment["XDG_RUNTIME_DIR"])
+        XCTAssertEqual(environment["CI"], "true")
+        XCTAssertEqual(environment["HEADLESS"], "true")
+        XCTAssertTrue(environment["PATH"]?.contains("/opt/homebrew/bin") == true)
+    }
+
+    func testRunnerEnvironmentPreservesGUIVariablesWhenEnabled() {
+        let environment = RunnerEnvironment.environment(
+            from: [
+                "PATH": "/usr/bin:/bin",
+                "DISPLAY": ":0",
+            ],
+            enableGUI: true
+        )
+
+        XCTAssertEqual(environment["DISPLAY"], ":0")
+        XCTAssertNil(environment["CI"])
+        XCTAssertNil(environment["HEADLESS"])
+    }
+
+    func testRunnerEnvironmentWritesPathSnapshot() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try RunnerEnvironment.writePathSnapshot(
+            in: temporaryDirectory.path,
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let written = try String(
+            contentsOf: temporaryDirectory.appendingPathComponent(".path"),
+            encoding: .utf8
+        )
+        XCTAssertEqual(
+            written,
+            "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin\n"
+        )
+    }
+
     func testAdministratorAuthenticationProcessUsesInteractiveTerminalHandles() {
         let process = UserIsolationService.makeAdministratorAuthenticationProcess()
 


### PR DESCRIPTION
## Summary

Fixes MacRunner-launched GitHub Actions runners missing Homebrew tools such as `npm` when the MacRunner app is launched by LaunchServices or as a login item.

## Root Cause

The MacRunner GUI process inherits launchd's limited PATH, e.g. `/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin`. That environment is then passed into runner startup/configuration, and the Actions runner snapshots it into `.path`. On Apple Silicon Macs, Homebrew installs Node/npm under `/opt/homebrew/bin`, so actions that shell out to `npm` fail even though `npm` is available in the user's interactive shell.

## Changes

- Add `RunnerEnvironment` to normalize runner PATH values with standard Homebrew locations.
- Use the normalized environment when configuring and launching non-isolated runners.
- Refresh the runner `.path` snapshot on start so existing runners recover after restart.
- Add unit coverage for PATH normalization, headless GUI stripping, GUI preservation, and `.path` writing.

## Verification

- `git diff --check`
- `swiftc -typecheck -target arm64-apple-macosx15.0 Sources/Services/RunnerEnvironment.swift`
- `swift test` was attempted, but the current checkout fails on pre-existing issues unrelated to this change: SwiftUI `#Preview` macro plugin missing for `MenuBarView.swift` and Swift 6 actor-send errors in `RunnerManager.swift` container service calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved process execution environment configuration with enhanced PATH normalization and deduplication
  * Better support for CI and headless execution modes with proper handling of GUI-related environment variables
  * Refined environment setup for runner processes ensuring consistent and optimized execution

* **Tests**
  * Added comprehensive test coverage for environment configuration, PATH management, and headless mode scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->