### PR TITLE
fix: refresh stale runner PATH snapshots

### DIFF
--- a/Sources/Services/RunnerEnvironment.swift
+++ b/Sources/Services/RunnerEnvironment.swift
@@ -55,4 +55,22 @@ enum RunnerEnvironment {
 
         try (path + "\n").write(to: pathFile, atomically: true, encoding: .utf8)
     }
+
+    static func pathSnapshotNeedsRefresh(in runnerDirectory: String) -> Bool {
+        let pathFile = URL(fileURLWithPath: runnerDirectory)
+            .appendingPathComponent(".path")
+
+        guard let snapshot = try? String(contentsOf: pathFile, encoding: .utf8) else {
+            return true
+        }
+
+        let entries = Set(
+            snapshot
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .split(separator: ":", omittingEmptySubsequences: true)
+                .map(String.init)
+        )
+
+        return !preferredPathEntries.allSatisfy { entries.contains($0) }
+    }
 }

--- a/Sources/Services/RunnerManager.swift
+++ b/Sources/Services/RunnerManager.swift
@@ -389,7 +389,11 @@ class RunnerManager: ObservableObject {
     /// but whose processes are no longer alive (e.g., after app restart or crash).
     /// Only restarts runners that were in the auto-restart set.
     func autoRestartRunners() async {
-        guard !runnersToAutoRestart.isEmpty else { return }
+        if runnersToAutoRestart.isEmpty {
+            await restartRunnersWithStalePathSnapshots()
+            return
+        }
+
         let ids = runnersToAutoRestart
         runnersToAutoRestart.removeAll()
 
@@ -403,6 +407,8 @@ class RunnerManager: ObservableObject {
                 }
             }
         }
+
+        await restartRunnersWithStalePathSnapshots()
     }
 
     // MARK: - Runner Management
@@ -824,6 +830,7 @@ class RunnerManager: ObservableObject {
         // group purely by `repo` string: an org-level runner and a repo-level runner can
         // share an identifier prefix, and the GitHub API endpoints differ by scope.
         let runnersByTarget = Dictionary(grouping: runners) { $0.target }
+        var becameIdleRunnerIDs = Set<UUID>()
 
         for (target, runnersInTarget) in runnersByTarget {
             // Only check runners that are currently running
@@ -849,6 +856,7 @@ class RunnerManager: ObservableObject {
                             await handleJobStarted(for: runners[index])
                         } else {
                             await handleJobCompleted(for: runners[index])
+                            becameIdleRunnerIDs.insert(runner.id)
                         }
                     }
                 }
@@ -858,6 +866,10 @@ class RunnerManager: ObservableObject {
                 // Don't save config for transient busy state changes
                 objectWillChange.send()
             }
+        }
+
+        if !becameIdleRunnerIDs.isEmpty {
+            await restartRunnersWithStalePathSnapshots(candidateIDs: becameIdleRunnerIDs)
         }
     }
 
@@ -1232,6 +1244,77 @@ class RunnerManager: ObservableObject {
             }
         }
         scheduledRestarts.removeAll()
+    }
+
+    private func restartRunnersWithStalePathSnapshots(candidateIDs: Set<UUID>? = nil) async {
+        var staleRunnerIDs: [UUID] = []
+        let runnerSnapshot = runners
+
+        for runner in runnerSnapshot {
+            guard runner.status == .running else { continue }
+            guard !runner.busy else { continue }
+            if let candidateIDs {
+                guard candidateIDs.contains(runner.id) else { continue }
+            }
+
+            let isolation = runner.effectiveIsolationMode(global: currentSettings.isolationMode)
+            guard isolation != .container else { continue }
+            guard processManager.isProcessAlive(for: runner.id) else { continue }
+            guard let runnerDir = try? RunnerDirectory.path(for: runner.id, isolation: isolation) else { continue }
+            guard RunnerEnvironment.pathSnapshotNeedsRefresh(in: runnerDir) else { continue }
+            guard await runnerIsConfirmedIdle(runner) else { continue }
+
+            staleRunnerIDs.append(runner.id)
+        }
+
+        for id in staleRunnerIDs {
+            await restartRunnerForPathSnapshotRefresh(id)
+        }
+    }
+
+    private func runnerIsConfirmedIdle(_ runner: Runner) async -> Bool {
+        guard let remoteRunners = try? await ghService.listRemoteRunners(for: runner.target),
+              let remoteRunner = remoteRunners.first(where: { $0.name == runner.name }) else {
+            return false
+        }
+
+        if let index = runners.firstIndex(where: { $0.id == runner.id }) {
+            runners[index].busy = remoteRunner.busy
+        }
+
+        return !remoteRunner.busy
+    }
+
+    private func restartRunnerForPathSnapshotRefresh(_ id: UUID) async {
+        guard let index = runners.firstIndex(where: { $0.id == id }) else { return }
+        guard runners[index].status == .running else { return }
+        guard !runners[index].busy else { return }
+
+        let runner = runners[index]
+        guard await runnerIsConfirmedIdle(runner) else { return }
+
+        logRunnerEvent(
+            for: runner,
+            message: "Runner PATH snapshot is stale; restarting to apply current Homebrew tool paths."
+        )
+
+        do {
+            try await stopRunner(id)
+            try await startRunner(id)
+
+            if let refreshedIndex = runners.firstIndex(where: { $0.id == id }) {
+                runners[refreshedIndex].lastRestartEvent = "Runner restarted to apply current Homebrew tool paths."
+                logRunnerEvent(for: runners[refreshedIndex], message: runners[refreshedIndex].lastRestartEvent ?? "")
+                saveConfiguration()
+            }
+        } catch {
+            if let refreshedIndex = runners.firstIndex(where: { $0.id == id }) {
+                runners[refreshedIndex].status = .error
+                runners[refreshedIndex].lastRestartEvent = "Failed to refresh runner PATH: \(error.localizedDescription)"
+                logRunnerEvent(for: runners[refreshedIndex], message: runners[refreshedIndex].lastRestartEvent ?? "")
+                saveConfiguration()
+            }
+        }
     }
 
     private func logRunnerEvent(for runner: Runner, message: String) {

--- a/Tests/MacRunnerTests/MacRunnerTests.swift
+++ b/Tests/MacRunnerTests/MacRunnerTests.swift
@@ -206,6 +206,44 @@ final class MacRunnerTests: XCTestCase {
         )
     }
 
+    func testRunnerEnvironmentDetectsMissingPathSnapshot() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        XCTAssertTrue(RunnerEnvironment.pathSnapshotNeedsRefresh(in: temporaryDirectory.path))
+    }
+
+    func testRunnerEnvironmentDetectsStalePathSnapshotMissingHomebrewEntries() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin\n".write(
+            to: temporaryDirectory.appendingPathComponent(".path"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(RunnerEnvironment.pathSnapshotNeedsRefresh(in: temporaryDirectory.path))
+    }
+
+    func testRunnerEnvironmentAcceptsCurrentPathSnapshotWithPreferredEntries() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try RunnerEnvironment.writePathSnapshot(
+            in: temporaryDirectory.path,
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        XCTAssertFalse(RunnerEnvironment.pathSnapshotNeedsRefresh(in: temporaryDirectory.path))
+    }
+
     func testAdministratorAuthenticationProcessUsesInteractiveTerminalHandles() {
         let process = UserIsolationService.makeAdministratorAuthenticationProcess()
 


### PR DESCRIPTION
## Summary
- detect stale runner `.path` snapshots that are missing Homebrew tool directories
- restart only idle process-based runners to apply the current PATH
- refresh stale runners after app auto-restart and when a busy runner becomes idle

## Root Cause
Live runners created before the PATH fix kept running with old `.path` snapshots like `/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin`, so Actions could not resolve Homebrew-installed tools such as `/opt/homebrew/bin/npm`. Restarting the runners manually fixed the immediate failure, but Mac Runner should repair this state at the runner-management layer.

## Validation
- Confirmed `ditto-app` runners rewrote `.path` with `/opt/homebrew/bin` after restart
- Reran ditto-app Firebase preview workflow successfully: https://github.com/ditto-assistant/ditto-app/actions/runs/27806209112
- `git diff --check`
- `swift test` attempted but blocked by existing local toolchain/repo issues: missing `PreviewsMacros` for `#Preview` and existing Containerization actor-isolation diagnostics in `RunnerManager`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container-isolated runners now automatically refresh environment paths during auto-restart cycles and after completing jobs, ensuring access to current tools.

* **Tests**
  * Added test coverage for environment path refresh detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->