### PR TITLE
fix: improve org runner reauth UX

### DIFF
--- a/Sources/Services/GHCLIService.swift
+++ b/Sources/Services/GHCLIService.swift
@@ -44,6 +44,11 @@ struct GitHubAuthState: Sendable, Equatable {
     }
 }
 
+struct GitHubAuthRecovery: Sendable, Equatable {
+    static let adminOrgScope = "admin:org"
+    static let adminOrgRefreshCommand = "gh auth refresh -h github.com -s admin:org"
+}
+
 final class GHCLIService: Sendable {
     static let shared = GHCLIService()
 
@@ -128,6 +133,20 @@ final class GHCLIService: Sendable {
         guard result.exitCode == 0 else {
             throw GHError.authFailed(result.stderr)
         }
+    }
+
+    func openAdminOrgReauth() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ghPath)
+        process.arguments = [
+            "auth", "refresh",
+            "-h", "github.com",
+            "-s", GitHubAuthRecovery.adminOrgScope,
+            "--clipboard"
+        ]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
     }
 
     func authStatus() async -> String {
@@ -270,9 +289,29 @@ final class GHCLIService: Sendable {
             "--jq", ".token"
         ])
         guard result.exitCode == 0, !result.stdout.isEmpty else {
-            throw GHError.apiFailed("Failed to get registration token: \(result.stderr)")
+            let detail = Self.registrationTokenFailureMessage(from: result.stderr)
+            throw GHError.apiFailed("Failed to get registration token: \(detail)")
         }
         return result.stdout
+    }
+
+    static func registrationTokenFailureMessage(from stderr: String) -> String {
+        guard requiresAdminOrgScope(stderr) else {
+            return stderr
+        }
+
+        return """
+        \(stderr)
+
+        To request the missing scope, run:
+        \(GitHubAuthRecovery.adminOrgRefreshCommand)
+        """
+    }
+
+    static func requiresAdminOrgScope(_ message: String) -> Bool {
+        let lowercased = message.lowercased()
+        return lowercased.contains(GitHubAuthRecovery.adminOrgScope)
+            || lowercased.contains("runners and runner groups")
     }
 
     func listRemoteRunners(for repo: String) async throws -> [RemoteRunner] {

--- a/Sources/Views/AddRunnerView.swift
+++ b/Sources/Views/AddRunnerView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct AddRunnerView: View {
@@ -20,6 +21,7 @@ struct AddRunnerView: View {
     @State private var isAdding = false
     @State private var addingProgress: (current: Int, total: Int)?
     @State private var errorMessage: String?
+    @State private var recoveryStatusMessage: String?
 
     enum IsolationSelection: String, CaseIterable, Identifiable {
         case global = "Global (from settings)"
@@ -48,6 +50,11 @@ struct AddRunnerView: View {
             let filtered = section.repos.filter { $0.lowercased().contains(query) }
             return filtered.isEmpty ? nil : (header: section.header, repos: filtered)
         }
+    }
+
+    private var shouldShowAdminOrgRecovery: Bool {
+        guard let errorMessage else { return false }
+        return GHCLIService.requiresAdminOrgScope(errorMessage)
     }
 
     var body: some View {
@@ -234,9 +241,14 @@ struct AddRunnerView: View {
                     }
 
                     if let error = errorMessage {
-                        Text(error)
-                            .foregroundColor(.red)
-                            .font(.caption)
+                        ErrorRecoveryView(
+                            message: error,
+                            showAdminOrgRecovery: shouldShowAdminOrgRecovery,
+                            recoveryStatusMessage: recoveryStatusMessage,
+                            onCopyError: { copyToPasteboard(error) },
+                            onCopyCommand: { copyToPasteboard(GitHubAuthRecovery.adminOrgRefreshCommand) },
+                            onOpenReauth: openAdminOrgReauth
+                        )
                     }
                 }
                 .padding()
@@ -273,7 +285,7 @@ struct AddRunnerView: View {
             }
             .padding()
         }
-        .frame(width: 400, height: 620)
+        .frame(width: 420, height: 680)
     }
 
     @ViewBuilder
@@ -405,6 +417,7 @@ struct AddRunnerView: View {
         isLoadingRepos = true
         defer { isLoadingRepos = false }
         errorMessage = nil
+        recoveryStatusMessage = nil
 
         do {
             if scope == .org {
@@ -438,6 +451,7 @@ struct AddRunnerView: View {
             addingProgress = nil
         }
         errorMessage = nil
+        recoveryStatusMessage = nil
 
         let baseName = name.isEmpty
             ? "mac-runner-\(Int.random(in: 1000...9999))"
@@ -492,5 +506,92 @@ struct AddRunnerView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    private func copyToPasteboard(_ value: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+        recoveryStatusMessage = "Copied."
+    }
+
+    private func openAdminOrgReauth() {
+        do {
+            try GHCLIService.shared.openAdminOrgReauth()
+            recoveryStatusMessage = "Opened GitHub reauth. The device code is on your clipboard."
+        } catch {
+            recoveryStatusMessage = "Could not open reauth: \(error.localizedDescription)"
+        }
+    }
+}
+
+private struct ErrorRecoveryView: View {
+    let message: String
+    let showAdminOrgRecovery: Bool
+    let recoveryStatusMessage: String?
+    let onCopyError: () -> Void
+    let onCopyCommand: () -> Void
+    let onOpenReauth: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.red)
+                Text(message)
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if showAdminOrgRecovery {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Request the missing org-admin scope:")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Text(GitHubAuthRecovery.adminOrgRefreshCommand)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.secondary.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                    HStack {
+                        Button {
+                            onCopyCommand()
+                        } label: {
+                            Label("Copy Command", systemImage: "doc.on.doc")
+                        }
+
+                        Button {
+                            onOpenReauth()
+                        } label: {
+                            Label("Open Reauth", systemImage: "safari")
+                        }
+
+                        Spacer()
+                    }
+                }
+            }
+
+            HStack {
+                Button {
+                    onCopyError()
+                } label: {
+                    Label("Copy Error", systemImage: "doc.on.clipboard")
+                }
+
+                if let recoveryStatusMessage {
+                    Text(recoveryStatusMessage)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(10)
+        .background(Color.red.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 }

--- a/Tests/MacRunnerTests/MacRunnerTests.swift
+++ b/Tests/MacRunnerTests/MacRunnerTests.swift
@@ -336,6 +336,19 @@ final class MacRunnerTests: XCTestCase {
         XCTAssertEqual(state.recoveryMessage, "GitHub authentication expired or is invalid. Run: gh auth login")
     }
 
+    func testRegistrationTokenFailureAddsAdminOrgRecoveryCommand() {
+        let message = """
+        gh: You must be an org admin or have the runners and runner groups fine-grained permission. (HTTP 403)
+        This API operation needs the "admin:org" scope.
+        """
+
+        let recovery = GHCLIService.registrationTokenFailureMessage(from: message)
+
+        XCTAssertTrue(GHCLIService.requiresAdminOrgScope(recovery))
+        XCTAssertTrue(recovery.contains(GitHubAuthRecovery.adminOrgRefreshCommand))
+        XCTAssertTrue(recovery.contains(message))
+    }
+
     func testJobNotificationPayloadFactoryBuildsStartedPayload() {
         let runner = Runner(name: "runner-1", repo: "omniaura/mac-runner")
         let run = WorkflowRunSummary(


### PR DESCRIPTION
## Summary
- detect org-runner registration failures that need the `admin:org` scope and append the exact `gh auth refresh -h github.com -s admin:org` recovery command
- add Add Runner dialog recovery controls to copy the command, copy the full error, and launch `gh auth refresh ... --clipboard` so the device flow opens with the code copied
- add coverage for the `admin:org` recovery message

## Validation
- `git diff --check`
- `swift test` *(fails before tests run on existing Swift 6/macOS build issues: Containerization actor diagnostics in `RunnerManager.swift` and missing `PreviewsMacros` for `#Preview` in `MenuBarView.swift`)*
- `swift test --filter MacRunnerTests/testRegistrationTokenFailureAddsAdminOrgRecoveryCommand` *(same package build failures before the filtered test can execute)*

## Live runner cleanup performed
- Refreshed local `gh` auth to include `admin:org`
- Added org-level runner `mac-runner-4584` for `ditto-assistant`; verified online via GitHub API
- Removed old repo-level runners from `ditto-assistant/backend` and `ditto-assistant/ditto-app`; both repo runner endpoints now report `total_count: 0`
- Cleared stale local Mac Runner config/directories, leaving only the org runner directory


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer recovery guidance when runner registration fails due to missing GitHub admin-org permissions.
  * Added an in-app option to copy the suggested command and open a reauthorization flow directly from the error view.

* **Bug Fixes**
  * Improved error messages to better explain permission-related failures instead of showing only raw command output.
  * Enhanced the runner setup screen to reset recovery status when retrying actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->